### PR TITLE
feat(profiles): PRK server export import

### DIFF
--- a/frontend/src/lib/tinkerprofiles/transformer.ts
+++ b/frontend/src/lib/tinkerprofiles/transformer.ts
@@ -1126,17 +1126,29 @@ export class ProfileTransformer {
     profile: TinkerProfile,
     result: ProfileImportResult
   ): Promise<void> {
-    const fetchRequests = nanoAoids.map(aoid => ({ aoid, targetQl: undefined }));
-    const itemMap = await this.fetchItems(fetchRequests);
+    if (nanoAoids.length === 0) return;
+
+    // Nanos are not interpolated - fetch each at its actual QL via the
+    // single-item endpoint (in parallel). Avoids the batch/interpolate path,
+    // which forces ql=1 on nanos and uses a key shape that doesn't match here.
+    const fetchPromises = nanoAoids.map(async aoid => {
+      try {
+        const response = await apiClient.getItem(aoid);
+        return { aoid, item: response.data ?? null };
+      } catch (error) {
+        console.warn(`[ProfileTransformer] Failed to fetch nano AOID ${aoid}:`, error);
+        return { aoid, item: null };
+      }
+    });
+
+    const fetched = await Promise.all(fetchPromises);
 
     const buffs: Item[] = [];
-    for (const aoid of nanoAoids) {
-      const key = `${aoid}:base`;
-      const item = itemMap.get(key);
+    for (const { aoid, item } of fetched) {
       if (item) {
         buffs.push(item);
       } else {
-        // Create a minimal fallback for unfetchable nanos
+        // Minimal fallback for unfetchable nanos
         buffs.push({
           id: aoid,
           aoid: aoid,


### PR DESCRIPTION
## Summary
- Adds PRK (Anarchy Online server profile export) decoder using `pako` for inflate of base64+zlib payloads
- Integrates PRK into `ProfileTransformer` with format detection in the import modal preview
- Splits server `BaseValue` into breed base + IP-derived points so imported skills land on the right totals
- Fixes PRK-imported active nanos rendering as "Nano <aoid> (fetch failed)" — now fetched via the non-interpolating single-item endpoint so they keep real names and QLs

## Test plan
- [ ] Import a PRK export and confirm the modal preview detects the PRK format
- [ ] Verify character, breed, profession, level, and abilities import correctly
- [ ] Verify trained skills show correct totals (breed base + IP)
- [ ] Verify active nanos appear in the Buffs panel with real names and QLs (no "fetch failed")
- [ ] Re-import the same export and confirm the profile updates without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)