### PR TITLE
fix(tinkerfite): show Martial Arts Item with profession + skill resolution

### DIFF
--- a/backend/app/api/services/weapon_filter_service.py
+++ b/backend/app/api/services/weapon_filter_service.py
@@ -88,12 +88,11 @@ class WeaponFilterService:
                 ])
             )
 
-        # Only include items with at least one requirement (excludes unequippable items)
-        query = query.join(
-            Action, Item.id == Action.item_id
-        ).join(
-            ActionCriteria, Action.id == ActionCriteria.action_id
-        )
+        # NOTE: Do not INNER JOIN Action/ActionCriteria here. Items with no
+        # action criteria (e.g. the "Martial Arts Item" templates, which have
+        # zero wield requirements) would be incorrectly dropped. The NOT IN
+        # subqueries below already handle exclusion of items whose requirements
+        # don't match the character.
 
         # OPTIMIZED: Use subqueries materialized once + NOT IN for exclusions
         # Much faster than multiple correlated NOT EXISTS subqueries that scan tables repeatedly

--- a/frontend/src/__tests__/utils/martial-arts-item.test.ts
+++ b/frontend/src/__tests__/utils/martial-arts-item.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for Martial Arts Item template selection in TinkerFite.
+ *
+ * The "Martial Arts Item" is special: profession determines which template
+ * family is used and the character's Martial Arts skill (skill 100) determines
+ * which tier within that family and the resolved QL.
+ *
+ * Spec source: client PlayerCharacter.cs:184-259.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectMartialArtsItem } from '@/utils/weapon-filtering';
+import type { WeaponCandidate, FiteInputState } from '@/types/weapon-analysis';
+
+const WEAPON_STAT_MIN_DAMAGE = 286;
+const WEAPON_STAT_MAX_DAMAGE = 285;
+const WEAPON_STAT_ATTACK_DELAY = 294;
+
+/**
+ * Build a minimal weapon candidate stub matching the shape used by
+ * the interpolation helpers.
+ */
+function makeTemplate(
+  aoid: number,
+  ql: number,
+  minDamage: number,
+  maxDamage: number,
+  attackDelay = 100
+): WeaponCandidate {
+  return {
+    id: aoid,
+    aoid,
+    name: 'Martial Arts Item',
+    ql,
+    is_nano: false,
+    stats: [
+      { id: 1, stat: WEAPON_STAT_MIN_DAMAGE, value: minDamage },
+      { id: 2, stat: WEAPON_STAT_MAX_DAMAGE, value: maxDamage },
+      { id: 3, stat: WEAPON_STAT_ATTACK_DELAY, value: attackDelay },
+    ],
+    actions: [],
+    equipable: false,
+  } as WeaponCandidate;
+}
+
+function makeState(profession: number, maSkill: number): FiteInputState {
+  return {
+    characterStats: {
+      breed: 1,
+      level: 220,
+      profession,
+      side: 0,
+      crit: 0,
+      targetAC: 0,
+      aggdef: 75,
+    },
+    weaponSkills: { 100: maSkill },
+    specialAttacks: {},
+    initiative: { meleeInit: 0, physicalInit: 0, rangedInit: 0 },
+    combatBonuses: { aao: 0, addDamage: 0, wrangle: 0 },
+  };
+}
+
+/**
+ * Mock candidate pool covering all 21 templates. Damage values are arbitrary
+ * but distinct per template so tier selection is verifiable.
+ */
+function makeAllTemplates(): WeaponCandidate[] {
+  return [
+    // Family 1: Martial Artist
+    makeTemplate(211352, 1, 3, 5),
+    makeTemplate(211353, 100, 25, 60),
+    makeTemplate(211354, 500, 90, 380),
+    makeTemplate(211357, 1, 91, 381),
+    makeTemplate(211358, 500, 203, 830),
+    makeTemplate(211363, 1, 204, 831),
+    makeTemplate(211364, 500, 425, 1280),
+    // Family 2: Shade
+    makeTemplate(211349, 1, 3, 5),
+    makeTemplate(211350, 100, 25, 60),
+    makeTemplate(211351, 500, 55, 258),
+    makeTemplate(211359, 1, 56, 259),
+    makeTemplate(211360, 500, 130, 682),
+    makeTemplate(211365, 1, 131, 683),
+    makeTemplate(211366, 500, 280, 890),
+    // Family 3: Generic
+    makeTemplate(43712, 1, 3, 5),
+    makeTemplate(144745, 100, 25, 60),
+    makeTemplate(43713, 500, 65, 280),
+    makeTemplate(211355, 1, 66, 281),
+    makeTemplate(211356, 500, 140, 715),
+    makeTemplate(211361, 1, 204, 831),
+    makeTemplate(211362, 500, 300, 990),
+  ];
+}
+
+describe('selectMartialArtsItem - family selection', () => {
+  const candidates = makeAllTemplates();
+
+  it('Martial Artist (profession 2) -> family 1', () => {
+    // Skill < 200 -> tier 0 templates 211352 (lo) + 211353 (hi)
+    const result = selectMartialArtsItem(candidates, makeState(2, 100));
+    expect(result).not.toBeNull();
+    // Low template's aoid leaks through after a clamped interpolation
+    expect(result!.aoid).toBe(211352);
+  });
+
+  it('Shade (profession 15) -> family 2', () => {
+    const result = selectMartialArtsItem(candidates, makeState(15, 100));
+    expect(result).not.toBeNull();
+    expect(result!.aoid).toBe(211349);
+  });
+
+  it('Other profession (e.g. Soldier, 1) -> family 3', () => {
+    const result = selectMartialArtsItem(candidates, makeState(1, 100));
+    expect(result).not.toBeNull();
+    expect(result!.aoid).toBe(43712);
+  });
+
+  it('Profession 0 (Any) -> family 3', () => {
+    const result = selectMartialArtsItem(candidates, makeState(0, 100));
+    expect(result).not.toBeNull();
+    expect(result!.aoid).toBe(43712);
+  });
+});
+
+describe('selectMartialArtsItem - tier selection and QL formula', () => {
+  const candidates = makeAllTemplates();
+
+  it('MA, skill 150 -> tier 0 (< 200), QL = 150/2 = 75', () => {
+    const result = selectMartialArtsItem(candidates, makeState(2, 150));
+    expect(result!.ql).toBe(75);
+  });
+
+  it('MA, skill 800 -> tier 1 (< 1000), QL = 800/2 = 400', () => {
+    const result = selectMartialArtsItem(candidates, makeState(2, 800));
+    expect(result!.ql).toBe(400);
+    // Tier 1 uses templates 211353 (low) + 211354 (high)
+    expect(result!.aoid).toBe(211353);
+  });
+
+  it('MA, skill 1500 -> tier 2 (< 2000), QL = (1500-1000)/2 = 250', () => {
+    const result = selectMartialArtsItem(candidates, makeState(2, 1500));
+    expect(result!.ql).toBe(250);
+    // Tier 2 uses templates 211357 (low) + 211358 (high)
+    expect(result!.aoid).toBe(211357);
+  });
+
+  it('MA, skill 3000 -> tier 3 (>= 2000), QL = (3000-2000)/2 = 500 (clamped)', () => {
+    const result = selectMartialArtsItem(candidates, makeState(2, 3000));
+    // Target QL is 500, hi template QL is 500 -> exact match
+    expect(result!.ql).toBe(500);
+    // At the high endpoint, the returned object uses the high template's aoid
+    expect(result!.aoid).toBe(211364);
+  });
+
+  it('Shade, skill 1500 -> family 2 tier 2 templates', () => {
+    const result = selectMartialArtsItem(candidates, makeState(15, 1500));
+    expect(result!.ql).toBe(250);
+    expect(result!.aoid).toBe(211359); // family 2 tier 2 low
+  });
+
+  it('Generic (Soldier), skill 1500 -> family 3 tier 2 templates', () => {
+    const result = selectMartialArtsItem(candidates, makeState(1, 1500));
+    expect(result!.ql).toBe(250);
+    expect(result!.aoid).toBe(211355); // family 3 tier 2 low
+  });
+
+  it('QL is floored to at least 1 even when MA skill is 0', () => {
+    const result = selectMartialArtsItem(candidates, makeState(2, 0));
+    expect(result!.ql).toBe(1);
+  });
+});
+
+describe('selectMartialArtsItem - damage interpolation', () => {
+  const candidates = makeAllTemplates();
+
+  it('linearly interpolates min/max damage to the target QL', () => {
+    // MA, skill 1500 -> family 1 tier 2: 211357 (QL 1, 91-381) + 211358 (QL 500, 203-830)
+    // QL target = 250, offset = 249, qlDelta = 499
+    // min: 91 + 249 * (203-91)/499 = 91 + 249 * 0.2244 = 91 + 55.89 = 146.89 -> 147
+    // max: 381 + 249 * (830-381)/499 = 381 + 249 * 0.8998 = 381 + 224.04 = 605.04 -> 605
+    const result = selectMartialArtsItem(candidates, makeState(2, 1500));
+    const min = result!.stats!.find((s) => s.stat === WEAPON_STAT_MIN_DAMAGE)!.value;
+    const max = result!.stats!.find((s) => s.stat === WEAPON_STAT_MAX_DAMAGE)!.value;
+    expect(min).toBe(147);
+    expect(max).toBe(605);
+  });
+});
+
+describe('selectMartialArtsItem - error cases', () => {
+  it('returns null when expected templates are missing', () => {
+    // Pass only family 2 templates but ask for family 1 (MA)
+    const partial = makeAllTemplates().filter((w) =>
+      [211349, 211350, 211351, 211359, 211360, 211365, 211366].includes(w.aoid!)
+    );
+    const result = selectMartialArtsItem(partial, makeState(2, 1500));
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/utils/weapon-filtering.ts
+++ b/frontend/src/utils/weapon-filtering.ts
@@ -14,7 +14,107 @@
 
 import type { WeaponCandidate, FiteInputState } from '@/types/weapon-analysis';
 import { checkRequirements } from './weapon-requirements';
-import { interpolateWeapon, sortWeaponsByQL } from './weapon-interpolation';
+import { interpolateWeapon, interpolateWeaponToQL, sortWeaponsByQL } from './weapon-interpolation';
+
+// ============================================================================
+// Martial Arts Item Template Selection
+// ============================================================================
+
+/**
+ * Martial Arts Item families and tiers.
+ *
+ * The "Martial Arts Item" represents a character's unarmed combat. The client
+ * (PlayerCharacter.cs:184-259) selects one of three template families based on
+ * profession, then picks an MA-skill tier within that family. Each tier
+ * specifies a (low_aoid, high_aoid) template pair and a QL formula derived
+ * from the character's Martial Arts skill.
+ *
+ * Family 1: Martial Artist (profession 2)
+ * Family 2: Shade (profession 15)
+ * Family 3: Generic fallback (all other professions)
+ */
+interface MATier {
+  /** MA skill upper bound (exclusive); use Infinity for the last tier */
+  maxSkill: number;
+  lowAoid: number;
+  highAoid: number;
+  /** Value subtracted from MA skill before dividing by 2 to compute QL */
+  qlOffset: number;
+}
+
+const MA_TIERS: Record<1 | 2 | 3, MATier[]> = {
+  // Family 1: Martial Artist
+  1: [
+    { maxSkill: 200,      lowAoid: 211352, highAoid: 211353, qlOffset: 0 },
+    { maxSkill: 1000,     lowAoid: 211353, highAoid: 211354, qlOffset: 0 },
+    { maxSkill: 2000,     lowAoid: 211357, highAoid: 211358, qlOffset: 1000 },
+    { maxSkill: Infinity, lowAoid: 211363, highAoid: 211364, qlOffset: 2000 },
+  ],
+  // Family 2: Shade
+  2: [
+    { maxSkill: 200,      lowAoid: 211349, highAoid: 211350, qlOffset: 0 },
+    { maxSkill: 1000,     lowAoid: 211350, highAoid: 211351, qlOffset: 0 },
+    { maxSkill: 2000,     lowAoid: 211359, highAoid: 211360, qlOffset: 1000 },
+    { maxSkill: Infinity, lowAoid: 211365, highAoid: 211366, qlOffset: 2000 },
+  ],
+  // Family 3: Generic fallback
+  3: [
+    { maxSkill: 200,      lowAoid: 43712,  highAoid: 144745, qlOffset: 0 },
+    { maxSkill: 1000,     lowAoid: 144745, highAoid: 43713,  qlOffset: 0 },
+    { maxSkill: 2000,     lowAoid: 211355, highAoid: 211356, qlOffset: 1000 },
+    { maxSkill: Infinity, lowAoid: 211361, highAoid: 211362, qlOffset: 2000 },
+  ],
+};
+
+function getMAFamily(profession: number): 1 | 2 | 3 {
+  if (profession === 2) return 1;   // Martial Artist
+  if (profession === 15) return 2;  // Shade
+  return 3;                          // Everyone else (including profession 0 = "Any")
+}
+
+function getMATier(family: 1 | 2 | 3, maSkill: number): MATier {
+  const tiers = MA_TIERS[family];
+  for (const tier of tiers) {
+    if (maSkill < tier.maxSkill) return tier;
+  }
+  return tiers[tiers.length - 1];
+}
+
+/**
+ * Select the single Martial Arts Item appropriate for the character.
+ *
+ * Picks the correct template family for the profession, the correct tier
+ * for the current MA skill, and interpolates between the tier's low/high
+ * templates to the QL computed from the family's formula.
+ *
+ * Martial Arts Items have no wield requirements, so equipability is implicit.
+ *
+ * @param candidates - All Martial Arts Item variants returned by the backend
+ * @param state - Character state (uses profession and weapon skill 100)
+ * @returns Single interpolated Martial Arts Item, or null if templates missing
+ */
+export function selectMartialArtsItem(
+  candidates: WeaponCandidate[],
+  state: FiteInputState
+): WeaponCandidate | null {
+  const profession = state.characterStats.profession;
+  const maSkill = state.weaponSkills[100] || 0;
+
+  const family = getMAFamily(profession);
+  const tier = getMATier(family, maSkill);
+
+  // QL is computed from MA skill, floored at 1
+  const targetQL = Math.max(1, Math.floor((maSkill - tier.qlOffset) / 2));
+
+  const lowTpl = candidates.find((w) => w.aoid === tier.lowAoid);
+  const highTpl = candidates.find((w) => w.aoid === tier.highAoid);
+
+  if (!lowTpl || !highTpl) {
+    return null;
+  }
+
+  return interpolateWeaponToQL(lowTpl, highTpl, targetQL);
+}
 
 // ============================================================================
 // Main Equipable Weapons Filter
@@ -52,9 +152,16 @@ export function getEquipableWeapons(
     // Get all weapons with same name
     let sameWeapons = weapons.filter((w) => w.name === weapon.name);
 
-    // Special handling for Martial Arts Items (profession-specific)
+    // Special handling for Martial Arts Item: profession + MA-skill drive
+    // template selection and QL is computed from MA skill rather than
+    // resolved by the generic equipability search.
     if (weapon.name === 'Martial Arts Item') {
-      sameWeapons = filterMartialArtsItemsByProfession(sameWeapons, state);
+      processedNames.add(weapon.name);
+      const selected = selectMartialArtsItem(sameWeapons, state);
+      if (selected) {
+        equipableWeapons.push(selected);
+      }
+      continue;
     }
 
     // If only one weapon variant, check if equipable
@@ -91,57 +198,6 @@ export function getEquipableWeapons(
   }
 
   return equipableWeapons;
-}
-
-/**
- * Filter Martial Arts Items by profession
- *
- * Port of legacy code lines 462-467
- *
- * Martial Arts Items have profession-specific variants.
- * Filter to only those matching the character's profession.
- * For profession 0 ("Any"), use profession 1 (Soldier) items.
- *
- * @param martialArtsItems - All Martial Arts Item variants
- * @param state - Character state
- * @returns Filtered variants for this profession
- */
-function filterMartialArtsItemsByProfession(
-  martialArtsItems: WeaponCandidate[],
-  state: FiteInputState
-): WeaponCandidate[] {
-  const profession = state.characterStats.profession;
-
-  // Profession 0 = "Any", use profession 1 (Soldier) items
-  const targetProfession = profession === 0 ? 1 : profession;
-
-  return martialArtsItems.filter((weapon) => {
-    // Find WIELD actions (action=8)
-    const wearActions = weapon.actions?.filter((a) => a.action === 8) || [];
-
-    // Check if any WEAR action has profession requirement
-    for (const action of wearActions) {
-      const criteria = action.criteria || [];
-
-      // Find profession criteria (stat 60)
-      const profCriteria = criteria.filter((c) => c.value1 === 60);
-
-      if (profCriteria.length === 0) {
-        // No profession requirement, include it
-        return true;
-      }
-
-      // Check if any profession criterion matches
-      for (const criterion of profCriteria) {
-        if (criterion.value2 === targetProfession) {
-          return true;
-        }
-      }
-    }
-
-    // No matching profession requirement found
-    return false;
-  });
 }
 
 // ============================================================================

--- a/frontend/src/utils/weapon-interpolation.ts
+++ b/frontend/src/utils/weapon-interpolation.ts
@@ -121,6 +121,82 @@ export function interpolateWeapon(
   return null;
 }
 
+/**
+ * Interpolate a weapon to a specific target QL (no requirement checking)
+ *
+ * Unlike interpolateWeapon() which finds the highest equipable QL, this
+ * targets an exact QL. Used for items whose effective QL is computed from
+ * a non-standard formula (e.g. Martial Arts Item, where QL is derived from
+ * the character's MA skill rather than from the templates' own QLs).
+ *
+ * The target QL is clamped to [loQL, hiQL].
+ *
+ * @param loWeapon - Low-QL template
+ * @param hiWeapon - High-QL template
+ * @param targetQL - Desired final QL (will be clamped to template range)
+ * @returns Interpolated weapon at the (clamped) target QL
+ */
+export function interpolateWeaponToQL(
+  loWeapon: WeaponCandidate,
+  hiWeapon: WeaponCandidate,
+  targetQL: number
+): WeaponCandidate {
+  const loQL = loWeapon.ql || 1;
+  const hiQL = hiWeapon.ql || 1;
+  const qlDelta = hiQL - loQL;
+
+  const clampedQL = Math.max(loQL, Math.min(hiQL, targetQL));
+  const offset = clampedQL - loQL;
+
+  // Degenerate cases: no delta, or target is at the low endpoint
+  if (qlDelta <= 0 || offset <= 0) {
+    return {
+      ...loWeapon,
+      ql: clampedQL,
+      interpolatedQL: clampedQL,
+      equipable: true,
+    };
+  }
+
+  // Target is exactly at the high endpoint
+  if (offset >= qlDelta) {
+    return {
+      ...hiWeapon,
+      ql: clampedQL,
+      interpolatedQL: clampedQL,
+      equipable: true,
+    };
+  }
+
+  const loStats = extractWeaponStatsForInterpolation(loWeapon);
+  const hiStats = extractWeaponStatsForInterpolation(hiWeapon);
+
+  const minDmgDelta = (hiStats.minDamage - loStats.minDamage) / qlDelta;
+  const maxDmgDelta = (hiStats.maxDamage - loStats.maxDamage) / qlDelta;
+  const critDmgDelta = (hiStats.critBonus - loStats.critBonus) / qlDelta;
+
+  let arCapDelta = 0;
+  if (loStats.arCap !== null && hiStats.arCap !== null) {
+    arCapDelta = (hiStats.arCap - loStats.arCap) / qlDelta;
+  }
+
+  return {
+    ...loWeapon,
+    ql: clampedQL,
+    interpolatedQL: clampedQL,
+    equipable: true,
+    stats: interpolateStats(
+      loWeapon.stats,
+      offset,
+      minDmgDelta,
+      maxDmgDelta,
+      critDmgDelta,
+      arCapDelta,
+      loStats
+    ),
+  };
+}
+
 // ============================================================================
 // Stat Extraction & Interpolation
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Root cause:** The Martial Arts Item (the unarmed-combat staple for Martial Artists) was being filtered out of TinkerFite. All 21 of its template variants have zero `actions` / `action_criteria` rows because they have no wield requirements — anyone can use their fists. Two filters dropped them: the backend's INNER JOIN on `actions`/`action_criteria` and the frontend's `filterMartialArtsItemsByProfession`, which assumed profession was encoded as a stat-60 criterion.
- **Backend:** Removed the INNER JOIN. The existing `NOT IN` subqueries already exclude items whose actual requirements don't match (NPC, breed, profession, expansion), so dropping the JOIN doesn't relax real gating.
- **Frontend:** Replaced the broken profession filter with `selectMartialArtsItem`, which mirrors the client's `PlayerCharacter.cs:184-259` template selection: profession → family (2 = MA, 15 = Shade, else = Generic); MA skill → tier (`<200`, `<1000`, `<2000`, `>=2000`); look up `(lowAoid, highAoid)` and interpolate to a QL computed by the family's formula.
- Added `interpolateWeaponToQL(lo, hi, targetQL)` because the existing interpolation searches for the highest *equipable* QL, while these items need interpolation to a specific computed QL.

## Test Plan

- [x] 13 new unit tests in `frontend/src/__tests__/utils/martial-arts-item.test.ts` covering family selection, all four tier boundaries, the QL formula, the spec example (MA + skill 1500 → QL 250, min 147, max 605), and the missing-template error case.
- [x] `weapon-calculations.test.ts` and `weapon-special-attacks.test.ts` still pass (54/54 total).
- [ ] In TinkerFite: load a Martial Artist profile, click **Update Weapons** to clear the IndexedDB cache, and confirm a single "Martial Arts Item" row appears with QL matching the family's formula.
- [ ] Repeat for a Shade profile — should hit family 2 templates.
- [ ] Repeat for a non-MA / non-Shade profile (e.g. Soldier) with MA skill set — should hit family 3 templates.
- [ ] After deploy, flush the `weapons_analyze` server cache (or wait out the 1h TTL) so existing cached responses pick up the broader weapon set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)