### PR TITLE
fix(tinkerfite): use pointsFromIp as trained-skill indicator

### DIFF
--- a/frontend/src/views/TinkerFite.vue
+++ b/frontend/src/views/TinkerFite.vue
@@ -131,9 +131,15 @@ async function fetchWeapons() {
     const profile = activeProfile.value;
     const weaponSkills = inputState.value.weaponSkills;
 
-    // Filter to skills the character has actually trained (IP spent on them)
+    // Filter to skills the character has actually trained.
+    //
+    // Use pointsFromIp (the IP-purchased skill points) rather than ipSpent
+    // (the IP-cost field): pointsFromIp is populated for both natively
+    // created and PRK-imported profiles, while ipSpent is only incrementally
+    // tracked when the user trains a skill inside this app - imported
+    // profiles leave it at 0.
     const trained = Object.entries(weaponSkills).filter(
-      ([skill_id]) => (profile.skills[Number(skill_id)]?.ipSpent ?? 0) > 0
+      ([skill_id]) => (profile.skills[Number(skill_id)]?.pointsFromIp ?? 0) > 0
     );
 
     const top3 = trained


### PR DESCRIPTION
The previous commit checked ipSpent > 0 to determine which weapon skills the character had trained. This excluded PRK-imported profiles entirely: the PRK transformer populates pointsFromIp (the IP-purchased skill points) from the server's BaseValue, but leaves ipSpent at 0 to be "recalculated by IP tracker" - except the IP tracker only increments ipSpent when a skill is trained inside this app, never backfilling from imports.

pointsFromIp is the correct universal "is trained" indicator: it's set the same way for both natively created and imported profiles.