### PR TITLE
fix(tinkernukes): stop applying NanoInit to recharge time

### DIFF
--- a/frontend/src/components/nukes/NukeTable.vue
+++ b/frontend/src/components/nukes/NukeTable.vue
@@ -218,10 +218,9 @@ const tableData = computed(() => {
 
     // Calculate modified recharge time (in seconds)
     // nano.rechargeTime is in centiseconds, convert to seconds for calculations
-    // Pass rechargeDelayCap (stat 524) to enforce minimum recharge time
+    // NanoInit does NOT affect recharge; only the rechargeDelayCap (stat 524) clamp applies
     const rechargeTime = calculateRechargeTime(
       nano.rechargeTime,
-      characterStats.nanoInit,
       nano.rechargeDelayCap
     );
 

--- a/frontend/src/types/offensive-nano.ts
+++ b/frontend/src/types/offensive-nano.ts
@@ -203,7 +203,7 @@ export interface CharacterStats {
   /** Psychic ability (affects nano regen tick speed) */
   psychic: number;
 
-  /** Nano Init skill (reduces cast time and recharge time) */
+  /** Nano Init skill (reduces cast time only; does not affect recharge time) */
   nanoInit: number;
 
   /** Max Nano skill (total nano pool size) */

--- a/frontend/src/utils/nuke-casting-calculations.ts
+++ b/frontend/src/utils/nuke-casting-calculations.ts
@@ -75,51 +75,42 @@ export function calculateCastTime(
 }
 
 /**
- * Calculate modified recharge time based on Nano Init skill
+ * Calculate modified recharge time
  *
- * Uses the same two-tier scaling formula as cast time:
- * - Below 1200 init: 1:2 ratio (init/2 reduction)
- * - Above 1200 init: Additional 1:6 ratio ((init-1200)/6 reduction)
+ * NanoInit (Nano Initiative) does NOT affect recharge time in Anarchy Online —
+ * it only reduces cast/attack time (see {@link calculateCastTime}). Recharge is a
+ * separate phase, so the base recharge is returned unchanged apart from the hard
+ * minimum clamp.
  *
  * Hard minimum (RechargeDelayCap):
  * - If stat 524 exists: use its value as minimum (can be < 100cs)
  * - If stat 524 not present: use default 100cs (1.00 second) minimum
  *
  * @param baseRecharge - Base recharge time in centiseconds (from database)
- * @param nanoInit - Character's Nano Init skill value
  * @param rechargeDelayCap - RechargeDelayCap from stat 524, or undefined for default 1.00s minimum
  * @returns Modified recharge time in seconds with 2 decimal precision
  *
  * @example
- * // Nano with 500cs base recharge, 1200 init, no cap stat
- * calculateRechargeTime(500, 1200) // Returns 1.00 (500 - 600 = -100cs, clamped to 100cs default)
+ * // Nano with 500cs base recharge, no cap stat
+ * calculateRechargeTime(500) // Returns 5.00
  *
  * @example
- * // Nano with 800cs base recharge, 1800 init, 150cs cap from stat 524
- * calculateRechargeTime(800, 1800, 150) // Returns 1.50 (800 - 1000 = -200cs, clamped to 150cs cap)
+ * // Nano with 80cs base recharge, no cap stat (clamped to 100cs default)
+ * calculateRechargeTime(80) // Returns 1.00
  *
  * @example
- * // Nano with 300cs base recharge, 2000 init, 50cs cap from stat 524
- * calculateRechargeTime(300, 2000, 50) // Returns 0.50 (capped at 50cs from stat 524)
+ * // Nano with 80cs base recharge, 50cs cap from stat 524
+ * calculateRechargeTime(80, 50) // Returns 0.80 (above 50cs cap)
  */
 export function calculateRechargeTime(
   baseRecharge: number,
-  nanoInit: number,
   rechargeDelayCap?: number
 ): number {
-  // Two-tier reduction calculation (same as cast time)
-  const firstTierReduction = Math.floor(nanoInit / 2);
-  const secondTierReduction = Math.floor(Math.max(0, nanoInit - 1200) / 6);
-  const totalReduction = firstTierReduction + secondTierReduction;
-
-  // Apply reduction
-  const reducedRechargeCs = baseRecharge - totalReduction;
-
   // Determine effective cap: use stat 524 if present, otherwise default 100cs (1.00s)
   const effectiveCap = rechargeDelayCap !== undefined ? rechargeDelayCap : DEFAULT_DELAY_CAP_CS;
 
-  // Apply hard minimum
-  const modifiedRechargeCs = Math.max(effectiveCap, reducedRechargeCs);
+  // Apply hard minimum (no NanoInit reduction — recharge is not affected by NanoInit)
+  const modifiedRechargeCs = Math.max(effectiveCap, baseRecharge);
 
   // Convert centiseconds to seconds
   return centisecondsToSeconds(modifiedRechargeCs);

--- a/frontend/tests/utils/nuke-calculations.test.ts
+++ b/frontend/tests/utils/nuke-calculations.test.ts
@@ -358,16 +358,20 @@ describe('Casting Calculations', () => {
   });
 
   describe('calculateRechargeTime', () => {
-    it('should use same two-tier formula as cast time', () => {
-      // Same test cases as cast time
-      expect(calculateRechargeTime(500, 1200)).toBe(0.0); // 500 - 600 = 0
-
-      // 1800 init on 2000cs recharge
-      expect(calculateRechargeTime(2000, 1800)).toBe(10.0); // 2000 - 1000 = 1000cs
+    it('should NOT apply NanoInit reduction to recharge time', () => {
+      // Recharge is returned unchanged (NanoInit only affects cast time)
+      expect(calculateRechargeTime(2000)).toBe(20.0);
+      expect(calculateRechargeTime(500)).toBe(5.0);
     });
 
-    it('should never go below 0 recharge time', () => {
-      expect(calculateRechargeTime(100, 5000)).toBe(0.0);
+    it('should clamp to the default 100cs (1.00s) minimum', () => {
+      expect(calculateRechargeTime(80)).toBe(1.0);
+      expect(calculateRechargeTime(100)).toBe(1.0);
+    });
+
+    it('should clamp to an explicit rechargeDelayCap (stat 524)', () => {
+      expect(calculateRechargeTime(80, 50)).toBe(0.8); // above 50cs cap
+      expect(calculateRechargeTime(30, 50)).toBe(0.5); // clamped to 50cs cap
     });
   });
 

--- a/frontend/tests/utils/nuke-calculations.test.ts
+++ b/frontend/tests/utils/nuke-calculations.test.ts
@@ -313,8 +313,8 @@ describe('Casting Calculations', () => {
   describe('calculateCastTime - two-tier scaling', () => {
     it('should apply 1:2 ratio below 1200 init', () => {
       // 600 init = 300cs reduction
-      // 300cs base - 300cs = 0cs = 0.00s
-      expect(calculateCastTime(300, 600)).toBe(0.0);
+      // 300cs base - 300cs = 0cs, clamped to 100cs default cap = 1.00s
+      expect(calculateCastTime(300, 600)).toBe(1.0);
 
       // 400 init = 200cs reduction
       // 500cs base - 200cs = 300cs = 3.00s
@@ -327,12 +327,12 @@ describe('Casting Calculations', () => {
       expect(calculateCastTime(1000, 1200)).toBe(4.0);
 
       // 1800 init: floor(1800/2) + floor(600/6) = 900 + 100 = 1000cs reduction
-      // 1000cs - 1000cs = 0cs = 0.00s
-      expect(calculateCastTime(1000, 1800)).toBe(0.0);
+      // 1000cs - 1000cs = 0cs, clamped to 100cs default cap = 1.00s
+      expect(calculateCastTime(1000, 1800)).toBe(1.0);
 
       // 1806 init: floor(1806/2) + floor(606/6) = 903 + 101 = 1004cs reduction
-      // 1000cs - 1004cs = 0cs (clamped to 0) = 0.00s
-      expect(calculateCastTime(1000, 1806)).toBe(0.0);
+      // 1000cs - 1004cs = -4cs, clamped to 100cs default cap = 1.00s
+      expect(calculateCastTime(1000, 1806)).toBe(1.0);
     });
 
     it('should use Math.floor for both tiers', () => {
@@ -346,14 +346,19 @@ describe('Casting Calculations', () => {
       expect(calculateCastTime(1000, 1206)).toBe(3.96); // 1000 - 604 = 396cs
     });
 
-    it('should never go below 0 cast time', () => {
-      expect(calculateCastTime(100, 5000)).toBe(0.0);
-      expect(calculateCastTime(0, 1000)).toBe(0.0);
+    it('should never go below the delay cap', () => {
+      // No cap stat: clamped to 100cs default cap = 1.00s
+      expect(calculateCastTime(100, 5000)).toBe(1.0);
+      expect(calculateCastTime(0, 1000)).toBe(1.0);
+
+      // Explicit cap (stat 523) can drop below the default floor
+      expect(calculateCastTime(100, 5000, 0)).toBe(0.0);
+      expect(calculateCastTime(500, 5000, 50)).toBe(0.5);
     });
 
     it('should handle legacy TinkerNukes examples', () => {
-      // Example: 300cs base, 1200 init
-      expect(calculateCastTime(300, 1200)).toBe(0.0); // 300 - 600 = 0
+      // Example: 300cs base, 1200 init -> 300 - 600 = -300cs, clamped to 100cs = 1.00s
+      expect(calculateCastTime(300, 1200)).toBe(1.0);
     });
   });
 
@@ -875,13 +880,13 @@ describe('Legacy TinkerNukes Validation', () => {
   it('should validate cast time two-tier scaling', () => {
     // Legacy example: 300cs base, 600 init
     // Reduction: floor(600/2) = 300
-    // Result: 300 - 300 = 0cs = 0.00s
-    expect(calculateCastTime(300, 600)).toBe(0.0);
+    // Result: 300 - 300 = 0cs, clamped to 100cs default cap = 1.00s
+    expect(calculateCastTime(300, 600)).toBe(1.0);
 
     // Legacy example: 1000cs base, 1800 init
     // Reduction: floor(1800/2) + floor(600/6) = 900 + 100 = 1000
-    // Result: 1000 - 1000 = 0cs = 0.00s
-    expect(calculateCastTime(1000, 1800)).toBe(0.0);
+    // Result: 1000 - 1000 = 0cs, clamped to 100cs default cap = 1.00s
+    expect(calculateCastTime(1000, 1800)).toBe(1.0);
   });
 
   it('should validate nano regen tick speed formula', () => {


### PR DESCRIPTION
## Summary

A report flagged that TinkerNukes was using NanoInit to reduce **recharge** time. Confirmed — `calculateRechargeTime()` ran the same two-tier NanoInit reduction as cast time. In Anarchy Online, NanoInit (Nano Initiative) only reduces **cast/attack** time; recharge is a separate phase and is unaffected. The result was recharge times displayed too low.

## Changes

**Recharge fix**
- `frontend/src/utils/nuke-casting-calculations.ts` — `calculateRechargeTime()` no longer takes or applies `nanoInit`; it returns the base recharge clamped to `RechargeDelayCap` (stat 524, default 100cs).
- `frontend/src/components/nukes/NukeTable.vue` — call site updated to drop `characterStats.nanoInit`.
- `frontend/src/types/offensive-nano.ts` — corrected the misleading `nanoInit` doc comment.
- `frontend/tests/utils/nuke-calculations.test.ts` — rewrote recharge tests to assert no NanoInit reduction + cap clamping.

**Cast-time test cleanup (second commit)**
- Updated `calculateCastTime` assertions that predated the 100cs default delay cap (expected `0.00s` where the cap now yields `1.00s`), and added explicit `AttackDelayCap` (stat 523) cases below the default floor.

## Testing

`npx vitest run tests/utils/nuke-calculations.test.ts` → **84 passed**. Type-check clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)