### PR TITLE
fix(tinkerfite): clamp negative weapon skill values before analyze

### DIFF
--- a/frontend/src/views/TinkerFite.vue
+++ b/frontend/src/views/TinkerFite.vue
@@ -145,7 +145,12 @@ async function fetchWeapons() {
     const top3 = trained
       .sort((a, b) => b[1] - a[1])
       .slice(0, 3)
-      .map(([skill_id, value]) => ({ skill_id: Number(skill_id), value: Math.round(value) }));
+      // Clamp to an integer >= 0: skill totals can be fractional (percentage
+      // perk/buff bonuses) or deeply negative (large equipment debuffs, e.g. an
+      // item granting -4000 to a skill). The backend schema requires
+      // `value >= 0`, and an effective negative skill can't meet any positive
+      // weapon requirement, so 0 is the correct floor.
+      .map(([skill_id, value]) => ({ skill_id: Number(skill_id), value: Math.max(0, Math.round(value)) }));
 
     if (top3.length === 0) {
       console.warn(


### PR DESCRIPTION
## Problem

PR #25 fixed the fractional-value 422, but only merged the `Math.round` half. **Negative** skill totals still cause `POST /api/v1/weapons/analyze` to return **HTTP 422**, so imported profiles with a debuffed weapon skill still fail to load weapons.

## Root cause (confirmed via Playwright against the live site)

Skill totals are `base + equipmentBonus + perkBonus + buffBonus`. The failing profile (Remedy) had skill 133 (Multi Ranged) with `equipmentBonus: -4000` → `total: -3924`. The backend schema requires `value: int` with `ge=0`:

```
top_weapon_skills[1].value = -3924
"Input should be greater than or equal to 0"
```

## Fix

Clamp each weapon skill value with `Math.max(0, Math.round(value))`. An effective negative skill can't meet any positive weapon requirement, so `0` is the correct floor. (Keeps the `Math.round` already on main and adds the lower bound.)

## Verification

Replayed the exact failing request against the production backend in-browser:
- original (`value: -3924`) → **422**
- clamped (`value: 0`) → **200**, 945 weapons returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)